### PR TITLE
顧客ファイルをアップロードした時、差分的処理でファイルが更新できるようにしました。

### DIFF
--- a/src/Controller/CustomersController.php
+++ b/src/Controller/CustomersController.php
@@ -19,17 +19,17 @@ class CustomersController extends AppController
     {
         $query = $this->Customers->find();
         $keyword = $this->request->getQuery('keyword');
-    if (!empty($keyword)) {
-        $query->where([
-            'OR' => [
-                'name LIKE' => '%' . $keyword . '%',
-                'phone_number LIKE' => '%' . $keyword . '%',
-                'contact_person LIKE' => '%' . $keyword . '%',
-            ]
-        ]);
-    }
-    $customers = $this->paginate($query);
-    $this->set(compact('customers'));
+        if (!empty($keyword)) {
+            $query->where([
+                'OR' => [
+                    'name LIKE' => '%' . $keyword . '%',
+                    'phone_number LIKE' => '%' . $keyword . '%',
+                    'contact_person LIKE' => '%' . $keyword . '%',
+                ]
+            ]);
+        }
+        $customers = $this->paginate($query);
+        $this->set(compact('customers'));
     }
 
     /**
@@ -52,159 +52,196 @@ class CustomersController extends AppController
      */
     public function add()
     {
-     $connection = \Cake\Datasource\ConnectionManager::get('default');
-        \Cake\Log\Log::debug('DB接続先: ' . $connection->config()['database']);
+        /** @var Connection $connection */
+        $connection = \Cake\Datasource\ConnectionManager::get('default');
+        $customer   = $this->Customers->newEmptyEntity();
+        $messages   = [];
 
-        $customer = $this->Customers->newEmptyEntity();
-        $messages = [];
-
-        // Excelアップロード処理
-        if ($this->request->is('post') && $this->request->getData('excel_upload') !== null) {
+        // ── Excel ファイルが来たときだけ実行 ───────────
+        if ($this->request->is('post') && $this->request->getData('excel_upload')) {
             $file = $this->request->getData('excel_file');
-            
-            if ($file->getError() === UPLOAD_ERR_OK) {
-                \Cake\Log\Log::debug('Excelファイルアップロード成功');
-                
-                try {
-                    $spreadsheet = IOFactory::load($file->getStream()->getMetadata('uri'));
-                    $sheet = $spreadsheet->getActiveSheet();
-                    $rows = $sheet->toArray();
-                    
-                    \Cake\Log\Log::debug('Excel全データ: ' . print_r($rows, true));
-                    \Cake\Log\Log::debug('Excel行数: ' . count($rows));
-                    
-                    // ヘッダー行をチェック
-                    if (isset($rows[0])) {
-                        \Cake\Log\Log::debug('ヘッダー行: ' . print_r($rows[0], true));
-                    }
-
-                    $successCount = 0;
-                    $errorCount = 0;
-
-                    // 1行目はヘッダーとしてスキップ
-                    foreach (array_slice($rows, 1) as $rowIndex => $row) {
-                        $actualRowNumber = $rowIndex + 2; // 実際のExcelの行番号
-                        
-                        // 行全体が空かチェック
-                        $isEmpty = true;
-                        for ($i = 0; $i < 8; $i++) {
-                            if (isset($row[$i]) && trim((string)$row[$i]) !== '') {
-                                $isEmpty = false;
-                                break;
-                            }
-                        }
-                        
-                        if ($isEmpty) {
-                            \Cake\Log\Log::debug("行 {$actualRowNumber}: 空行のためスキップ");
-                            continue;
-                        }
-                        
-                        // デバッグ: 行データを出力
-                        \Cake\Log\Log::debug("行 {$actualRowNumber} データ: " . print_r($row, true));
-                        
-                        // 顧客IDの詳細チェック
-                        $rawCustomerId = isset($row[0]) ? trim((string)$row[0]) : '';
-                        if ($rawCustomerId === '' || $rawCustomerId === null) {
-                            \Cake\Log\Log::warning("行 {$actualRowNumber}: 顧客IDが空です");
-                            $messages[] = "行 {$actualRowNumber}: 顧客IDが入力されていません";
-                            $errorCount++;
-                            continue;
-                        }
-                        
-                        // 必須項目のチェック（店舗名、顧客名、電話番号）
-                        $bookstoreName = isset($row[1]) ? trim((string)$row[1]) : '';
-                        $customerName = isset($row[2]) ? trim((string)$row[2]) : '';
-                        $phoneNumber = isset($row[5]) ? trim((string)$row[5]) : ''; // 電話番号は列F
-                        
-                        if ($bookstoreName === '' || $customerName === '' || $phoneNumber === '') {
-                            $missingFields = [];
-                            if ($bookstoreName === '') $missingFields[] = '店舗名';
-                            if ($customerName === '') $missingFields[] = '顧客名';
-                            if ($phoneNumber === '') $missingFields[] = '電話番号';
-                            
-                            \Cake\Log\Log::warning("行 {$actualRowNumber}: 必須項目が不足 - " . implode(', ', $missingFields));
-                            $messages[] = "行 {$actualRowNumber}: " . implode(', ', $missingFields) . "が入力されていません";
-                            $errorCount++;
-                            continue;
-                        }
-
-                        // 顧客IDの処理と重複チェック
-                        $customer_id = str_pad($rawCustomerId, 5, '0', STR_PAD_LEFT);
-                        
-                        // 数値以外が含まれていないかチェック
-                        if (!ctype_digit($rawCustomerId)) {
-                            \Cake\Log\Log::warning("行 {$actualRowNumber}: 顧客IDは数値である必要があります - {$rawCustomerId}");
-                            $messages[] = "行 {$actualRowNumber}: 顧客ID「{$rawCustomerId}」は数値で入力してください";
-                            $errorCount++;
-                            continue;
-                        }
-                        
-                        $existingCustomer = $this->Customers->find()
-                            ->where(['customer_id' => $customer_id])
-                            ->first();
-                        
-                        if ($existingCustomer) {
-                            $messages[] = "行 {$actualRowNumber}: 顧客ID {$customer_id} は既に存在します";
-                            $errorCount++;
-                            continue;
-                        }
-
-                        $entity = $this->Customers->newEntity([
-                            'customer_id'     => $customer_id,
-                            'bookstore_name'  => $bookstoreName,
-                            'name'            => $customerName,
-                            'contact_person'  => isset($row[3]) ? trim((string)$row[3]) : '',
-                            'phone_number'    => $phoneNumber,
-                            'remark'          => isset($row[7]) ? trim((string)$row[7]) : '',
-                        ]);
-
-                        if ($this->Customers->save($entity)) {
-                            $successCount++;
-                        } else {
-                            $errors = $entity->getErrors();
-                            $errorMessages = [];
-                            foreach ($errors as $field => $validationErrors) {
-                                foreach ($validationErrors as $error) {
-                                    $errorMessages[] = $field . ': ' . $error;
-                                }
-                            }
-                            $messages[] = "行 {$actualRowNumber}: " . implode(', ', $errorMessages);
-                            $errorCount++;
-                            \Cake\Log\Log::error("行 {$actualRowNumber} 保存失敗: " . print_r($errors, true));
-                        }
-                    }
-
-                    if ($successCount > 0) {
-                        $this->Flash->success("{$successCount}件の顧客を正常に登録しました。");
-                    }
-                    if ($errorCount > 0) {
-                        $this->Flash->error("{$errorCount}件のエラーが発生しました。" . (!empty($messages) ? "\n" . implode("\n", array_slice($messages, 0, 5)) : ''));
-                    }
-                    
-                    return $this->redirect(['controller' => 'List', 'action' => 'customer']);
-                    
-                } catch (\Exception $e) {
-                    \Cake\Log\Log::error('Excel処理エラー: ' . $e->getMessage());
-                    $this->Flash->error('Excelファイルの処理中にエラーが発生しました: ' . $e->getMessage());
-                }
-            } else {
+            if ($file->getError() !== UPLOAD_ERR_OK) {
                 $this->Flash->error('ファイルのアップロードに失敗しました。');
+                return $this->redirect(['controller' => 'List', 'action' => 'customer']);
             }
+
+            // ■ ここから "1トランザクション" で実行 ■
+            $result = $connection->transactional(function () use ($file, &$messages) {
+
+                // Excel → 配列
+                $rows  = IOFactory::load($file->getStream()->getMetadata('uri'))
+                            ->getActiveSheet()
+                            ->toArray();
+
+                // 集計用
+                $insert = $update = $unchanged = $error = 0;
+
+                // 1行目ヘッダを飛ばす
+                foreach (array_slice($rows, 1) as $i => $row) {
+                    $rowNo = $i + 2;                       // Excel 上の行番号
+                    if ($this->isEmptyRow($row)) {         // 空行スキップ
+                        continue;
+                    }
+
+                    // ① 行をバリデーションして整形
+                    $check = $this->validateExcelRow($row, $rowNo);
+                    if (!$check['valid']) {
+                        $messages = array_merge($messages, $check['messages']);
+                        $error++;                          // バリデーション NG はロールバック対象
+                        continue;
+                    }
+                    $data = $check['data'];
+
+                    // ② 既存レコードを取得
+                    $entity = $this->Customers->find()
+                               ->where(['customer_id' => $data['customer_id']])
+                               ->first();
+
+                    if ($entity) {                         // --- UPDATE 用 ---
+                        $this->Customers->patchEntity($entity, $data, ['validate' => false]);
+                        if ($entity->isDirty()) {          // 差分があったら保存
+                            if (!$this->Customers->save($entity)) {
+                                $this->logEntityErrors($entity, $rowNo, $messages);
+                                $error++;
+                                continue;
+                            }
+                            $update++;
+                        } else {
+                            $unchanged++;
+                        }
+
+                    } else {                              // --- INSERT 用 ---
+                        $entity = $this->Customers->newEntity($data);
+                        if (!$this->Customers->save($entity)) {
+                            $this->logEntityErrors($entity, $rowNo, $messages);
+                            $error++;
+                            continue;
+                        }
+                        $insert++;
+                    }
+                }
+
+                // ③ 一件でもエラーがあれば false を返して rollback
+                if ($error) {
+                    return false;
+                }
+                return compact('insert', 'update', 'unchanged');   // commit
+            });
+
+            // ── トランザクションの結果判定 ────────────
+            if ($result === false) {        // rollback 済み
+                $this->Flash->error(
+                    "処理中にエラーが発生しロールバックしました。\n" .
+                    implode("\n", array_slice($messages, 0, 5))
+                );
+            } else {                        // commit 済み
+                ['insert' => $i, 'update' => $u, 'unchanged' => $c] = $result;
+                $msg = [];
+                if ($i) $msg[] = "新規登録 {$i} 件";
+                if ($u) $msg[] = "更新 {$u} 件";
+                if ($c) $msg[] = "変更なし {$c} 件";
+                $this->Flash->success('処理完了 - ' . implode(', ', $msg));
+            }
+
+            // 修正: 正しいリダイレクト先を指定
+            return $this->redirect(['controller' => 'List', 'action' => 'customer']);
         }
 
-        // 通常の単体登録処理
-        if ($this->request->is('post') && $this->request->getData('excel_upload') === null) {
+        // ── 通常の単体登録フォーム処理 ───────────────
+        if ($this->request->is('post')) {
             $customer = $this->Customers->patchEntity($customer, $this->request->getData());
             if ($this->Customers->save($customer)) {
-                $this->Flash->success(__('The customer has been saved.'));
-                return $this->redirect(['action' => 'index']);
+                $this->Flash->success('The customer has been saved.');
+                return $this->redirect(['controller' => 'List', 'action' => 'customer']);
             }
-            $this->Flash->error(__('The customer could not be saved. Please, try again.'));
+            $this->Flash->error('The customer could not be saved. Please, try again.');
         }
-        
+
         $this->set(compact('customer'));
     }
-   
+
+    /**
+     * 行が空かどうかをチェックする
+     */
+    private function isEmptyRow(array $row): bool
+    {
+        foreach ($row as $cell) {
+            if (trim((string)$cell) !== '') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Excelの1行分のバリデーション
+     */
+    private function validateExcelRow(array $row, int $rowNumber): array
+    {
+        $errors = [];
+        $data = [];
+
+        // 顧客IDのチェック
+        $rawCustomerId = isset($row[0]) ? trim((string)$row[0]) : '';
+        if (empty($rawCustomerId)) {
+            $errors[] = "顧客IDがありません（{$rowNumber}行目）";
+        } elseif (!ctype_digit($rawCustomerId)) {
+            $errors[] = "顧客IDは数値である必要があります（{$rowNumber}行目）";
+        } else {
+            $data['customer_id'] = str_pad($rawCustomerId, 5, '0', STR_PAD_LEFT);
+        }
+
+        // 店舗名のチェック
+        $bookstoreName = isset($row[1]) ? trim((string)$row[1]) : '';
+        if (empty($bookstoreName)) {
+            $errors[] = "店舗名がありません（{$rowNumber}行目）";
+        } else {
+            $data['bookstore_name'] = $bookstoreName;
+        }
+
+        // 顧客名のチェック
+        $customerName = isset($row[2]) ? trim((string)$row[2]) : '';
+        if (empty($customerName)) {
+            $errors[] = "顧客名がありません（{$rowNumber}行目）";
+        } else {
+            $data['name'] = $customerName;
+        }
+
+        // 担当者名（任意）
+        $data['contact_person'] = isset($row[3]) ? trim((string)$row[3]) : '';
+
+        // 電話番号のチェック
+        $phoneNumber = isset($row[5]) ? trim((string)$row[5]) : '';
+        if (empty($phoneNumber)) {
+            $errors[] = "電話番号がありません（{$rowNumber}行目）";
+        } else {
+            $data['phone_number'] = $phoneNumber;
+        }
+
+        // 備考（任意）
+        $data['remark'] = isset($row[7]) ? trim((string)$row[7]) : '';
+
+        return [
+            'valid' => empty($errors),
+            'messages' => $errors,
+            'data' => $data
+        ];
+    }
+
+    /**
+     * 保存失敗時のエラーログを出力
+     */
+    private function logEntityErrors($entity, int $rowNumber, array &$messages): void
+    {
+        $errors = $entity->getErrors();
+        foreach ($errors as $field => $fieldMessages) {
+            foreach ($fieldMessages as $msg) {
+                $errorMsg = "行 {$rowNumber}: {$field} - {$msg}";
+                $messages[] = $errorMsg;
+                \Cake\Log\Log::error($errorMsg);
+            }
+        }
+    }
 
     /**
      * Edit method

--- a/src/Controller/ListController.php
+++ b/src/Controller/ListController.php
@@ -32,6 +32,9 @@ class ListController extends AppController
         $customersTable = $this->fetchTable('Customers');
         $customers = $customersTable->find()->all();
         $this->set(compact('customers'));
+
+
+        
      
         $this->render('/CustomerList/index');
 


### PR DESCRIPTION
顧客ファイル追加画面で、元々アップロードしたexcelファイルを変更を加えて再度アップロードした場合、元のデータと新しくアップロードされたExcelファイルを見比べてデータベースに変更点だけ更新して保存されるようにしました。差分的処理の実施完了。

元のデータ
![image](https://github.com/user-attachments/assets/cd5671ab-340e-43bf-9126-3247e4184b83)]
↓
更新されたデータ
![image](https://github.com/user-attachments/assets/13dcc778-9f8c-4a68-ae6c-f6c618e6f2dc)

画面の上の方うに変更件数表示完了
![image](https://github.com/user-attachments/assets/fe932ed7-16b8-4160-bc26-d3b6010f1c90)
閉じていいissue#36