### PR TITLE
納品書印刷の時にボタンが表示されないようにしました。

### DIFF
--- a/templates/DeliveryList/detail.php
+++ b/templates/DeliveryList/detail.php
@@ -66,6 +66,56 @@
         .button:hover, .action-btn:hover {
             background-color: #1565c0;
         }
+
+        /* 印刷用スタイル */
+        @media print {
+            body {
+                background-color: white;
+                margin: 0;
+                padding: 0;
+            }
+            
+            .main-container {
+                max-width: none;
+                margin: 0;
+                background: white;
+                border-radius: 0;
+                box-shadow: none;
+                padding: 20px;
+            }
+            
+            h2 {
+                color: black;
+            }
+            
+            th {
+                background: #f0f0f0 !important;
+                -webkit-print-color-adjust: exact;
+                color-adjust: exact;
+            }
+            
+            tfoot td {
+                background: #f5f5f5 !important;
+                -webkit-print-color-adjust: exact;
+                color-adjust: exact;
+            }
+            
+            /* ボタンエリアを印刷時に非表示 */
+            .button-area {
+                display: none !important;
+            }
+            
+            /* ボタン個別でも非表示 */
+            .button, .action-btn {
+                display: none !important;
+            }
+            
+            /* ページ余白の調整 */
+            @page {
+                margin: 1cm;
+                size: A4;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
通常
<img width="897" height="612" alt="image" src="https://github.com/user-attachments/assets/454777f4-0cbb-454c-bcfe-e4786d5f6e8c" />
↓
印刷時
<img width="1006" height="816" alt="image" src="https://github.com/user-attachments/assets/b4a49d06-9ecc-4486-be94-3abe3f26e966" />
